### PR TITLE
Calibrate extruder rotation distance

### DIFF
--- a/config/printer.cfg
+++ b/config/printer.cfg
@@ -65,7 +65,7 @@ enable_force_move : True
 step_pin:THR:PB9
 dir_pin:!THR:PB8
 enable_pin:!THR:PC15
-rotation_distance: 53.7  #22.6789511 Bondtech 5mm Drive Gears
+rotation_distance: 54.11  #22.6789511 Bondtech 5mm Drive Gears
 gear_ratio: 1517:170
 microsteps: 16
 full_steps_per_rotation: 200	#200 for 1.8 degree, 400 for 0.9 degree


### PR DESCRIPTION
Original rotation distance seems to be off by 1%.
Here's a more accurate value.