### PR TITLE
Update gcode_macro.cfg for Q2/Q2C with QiDi Box

### DIFF
--- a/config/gcode_macro.cfg
+++ b/config/gcode_macro.cfg
@@ -174,17 +174,17 @@ gcode:
     M204 S5000
     {% if (printer.gcode_move.position.y) > 270 %}
         {% if (printer.gcode_move.position.x) > 112 or (printer.gcode_move.position.x) < 85 %}
-            G1 Y270 F20000
-            G1 X85 F20000
-            G1 Y270 F20000
-            G1 Y287.5 F1500
+            G1 Y270 F15000
+            G1 X87.5 F15000
+            G1 Y270 F15000
+            G1 Y287.25 F1500
         {% endif %}
-        G1 X85 F20000
-        G1 Y287.5 F1500
+        G1 X87.5 F15000
+        G1 Y287.25 F1500
     {% else %}
-        G1 X85 F20000
-        G1 Y260 F20000
-        G1 Y287.5 F1500
+        G1 X87.5 F15000
+        G1 Y260 F15000
+        G1 Y287.25 F1500
     {% endif %}
 
 [gcode_macro EXTRUSION_AND_FLUSH]
@@ -825,14 +825,14 @@ gcode:
     M204 S10000
     {% if (printer.gcode_move.position.x) < 15 %}
         G1 X15 F9000
-        G1 Y0.5 F9000
+        G1 Y0.6 F9000
     {% endif %}
-    G1 Y0.5 F15000
+    G1 Y0.6 F15000
     G1 X15 F15000
-    G1 X-0.5 F5000
+    G1 X-0.4 F5000
     G4 P1000
     G1 X1 F1000
-    G1 X-0.5 F5000
+    G1 X-0.4 F5000
     G4 P1000
     G1 X1 F1000
     G4 P1000


### PR DESCRIPTION
Resolve potential toolhead / frame collisions that create misalignment, that causes layer shift after filament change on Q2/Q2C with Box.
- Priority High: Changes in some positions for `MOVE_TO_TRASH` and `CUT_FILAMENT_1` that move the toolhead very slightly further away from the frame and chamber walls.
- Priority Low: Reduce acceleration for some toolhead movements. May not be strictly necessary.